### PR TITLE
Initialize Codex bootloader scaffolding

### DIFF
--- a/.codex-scope.json
+++ b/.codex-scope.json
@@ -1,0 +1,4 @@
+{
+  "allowed_folders": ["src/modules/**", "src/ops/codex-bootloader/**"],
+  "forbidden_files": ["src/pages/Build.tsx", "src/components/ui/**"]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# BootloaderAgent
+
+The **BootloaderAgent** initializes and maintains Codex modules.
+It can be invoked in any repository that includes this bootloader.
+
+## Capabilities
+
+- Scaffold new modules from templates
+- Clone `AGENTS.md` and `TODO.md` into new module folders
+- Generate `route.ts` and `README.md` stubs if missing
+- Use `.codex-scope.json` for guardrails
+
+## Behavior
+
+1. Reference `.codex-scope.json` to determine where files may be written.
+2. When a new module name is provided, create `src/modules/<name>/` and copy
+   the bootloader's `AGENTS.md` and `TODO.md` as starting points.
+3. If `route.ts` or `README.md` are missing in a module, generate simple stubs
+   so the module compiles.
+4. Execute each module's `TODO.md` recursively, creating any subfolders and
+   agents requested by those TODO items.
+
+This agent provides the minimal scaffolding so other agents can begin building
+features immediately.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,8 @@
+# Bootloader TODO
+
+- [ ] Generate AGENTS.md
+- [ ] Generate TODO.md
+- [ ] Generate `.codex-scope.json`
+- [ ] Generate `run-all.md`
+- [ ] Generate `bootstrap-module.ts`
+- [ ] Return control to `/src/modules/TODO.md` if called externally

--- a/bootstrap-module.ts
+++ b/bootstrap-module.ts
@@ -1,0 +1,28 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+async function main() {
+  const [name] = process.argv.slice(2);
+  if (!name) {
+    console.error('Usage: ts-node src/ops/codex-bootloader/bootstrap-module.ts <name>');
+    process.exit(1);
+  }
+
+  const repoRoot = process.cwd();
+  const moduleDir = path.join(repoRoot, 'src', 'modules', name);
+  await fs.mkdir(moduleDir, { recursive: true });
+
+  const bootloaderDir = __dirname;
+  for (const file of ['AGENTS.md', 'TODO.md']) {
+    const src = path.join(bootloaderDir, file);
+    const dest = path.join(moduleDir, file);
+    await fs.copyFile(src, dest);
+  }
+
+  console.log(`Module '${name}' created at ${moduleDir}`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/run-all.md
+++ b/run-all.md
@@ -1,0 +1,9 @@
+# Run All Modules
+
+This document guides Codex to execute every module's TODO list.
+
+1. Look for `/src/modules/**/TODO.md` in the current repository.
+2. For each module found, read its `AGENTS.md` and `TODO.md` and complete the
+   checklist recursively.
+3. If no modules are present, return control to `src/ops/codex-bootloader/TODO.md`
+   so the bootloader can continue.


### PR DESCRIPTION
## Summary
- add `AGENTS.md` describing the BootloaderAgent
- create bootloader `TODO.md`
- define codex scope
- document how to run all modules
- add TypeScript module bootstrap script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851794a828c8328bb07731929fd5318