### PR TITLE
Initialize Codex bootloader scaffolding

### DIFF
--- a/.codex-scope.json
+++ b/.codex-scope.json
@@ -1,0 +1,4 @@
+{
+  "allowed_folders": ["src/modules/**", "src/ops/codex-bootloader/**"],
+  "forbidden_files": ["src/pages/Build.tsx", "src/components/ui/**"]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# BootloaderAgent
+
+The **BootloaderAgent** initializes and maintains Codex modules.
+It can be invoked in any repository that includes this bootloader.
+
+## Capabilities
+
+- Scaffold new modules from templates
+- Clone `AGENTS.md` and `TODO.md` into new module folders
+- Generate `route.ts` and `README.md` stubs if missing
+- Use `.codex-scope.json` for guardrails
+
+## Behavior
+
+1. Reference `.codex-scope.json` to determine where files may be written.
+2. When a new module name is provided, create `src/modules/<name>/` and copy
+   the bootloader's `AGENTS.md` and `TODO.md` as starting points.
+3. If `route.ts` or `README.md` are missing in a module, generate simple stubs
+   so the module compiles.
+4. Execute each module's `TODO.md` recursively, creating any subfolders and
+   agents requested by those TODO items.
+
+This agent provides the minimal scaffolding so other agents can begin building
+features immediately.

--- a/AGENT_TYPES.md
+++ b/AGENT_TYPES.md
@@ -1,0 +1,10 @@
+| Agent Name | Role | Typical Outputs |
+|------------|------|-----------------|
+| StrategyAgent | Generates project roadmap and agent roles | roadmap.md, task tree |
+| ResearchAgent | Gathers competitive intelligence or trend data | research.md |
+| DesignerAgent | Creates layout instructions or Figma directives | design-brief.md |
+| MCPIntegrationAgent | Generates code for Figma Write API | inject_from_schema.js |
+| DeveloperAgent | Writes code, scripts, and components | TypeScript files |
+| QAAgent | Spawns sub-agents for logging, evaluation, and compliance | test/*.ts, runtime-log.json |
+| RevealAgent | Streams logs for UI display | RevealPanel.tsx |
+| OutcomeAgent | Scores engagement or output quality | report.md, score.json |

--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ You can safely edit `TODO.md` or `AGENTS.md` in any module — the originals rem
 
 ---
 
+## 🔮 Agent Superpowers
+
+Codex agents can spawn sub-agents recursively. Use `AGENT_TYPES.md` to pick the right roles and design an entire swarm. With a well-defined roadmap, Codex can self-plan and then self-build complete applications.
+
+## 🚀 Quickstart
+
+```bash
+git submodule add https://github.com/gentlyventures/codex-bootloader src/ops/codex-bootloader
+npx ts-node src/ops/codex-bootloader/bootstrap-module.ts fiveblocks
+```
+
 ## ✅ Compatible With
 
 * Codex (chat.openai.com/codex)

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,8 @@
+# Bootloader TODO
+
+- [ ] Generate AGENTS.md
+- [ ] Generate TODO.md
+- [ ] Generate `.codex-scope.json`
+- [ ] Generate `run-all.md`
+- [ ] Generate `bootstrap-module.ts`
+- [ ] Return control to `/src/modules/TODO.md` if called externally

--- a/agent-factory.ts
+++ b/agent-factory.ts
@@ -1,0 +1,43 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+interface Args {
+  module: string;
+  agent: string;
+}
+
+function parseArgs(): Args {
+  const args: Args = { module: '', agent: '' };
+  for (const arg of process.argv.slice(2)) {
+    const [key, value] = arg.replace(/^--/, '').split('=');
+    if (key === 'module') args.module = value;
+    if (key === 'agent') args.agent = value;
+  }
+  if (!args.module || !args.agent) {
+    console.error('Usage: ts-node agent-factory.ts --module=<module> --agent=<name>');
+    process.exit(1);
+  }
+  return args;
+}
+
+async function createAgentFolder(baseDir: string, module: string, agent: string) {
+  const agentDir = path.join(baseDir, 'src', 'modules', module, agent);
+  await fs.mkdir(agentDir, { recursive: true });
+
+  const boilerplate = `# ${agent}\n\nDescribe the ${agent} agent here.`;
+  await fs.writeFile(path.join(agentDir, 'AGENTS.md'), boilerplate);
+  await fs.writeFile(path.join(agentDir, 'TODO.md'), '- [ ] Define tasks for this agent');
+
+  console.log(`Created ${agentDir}`);
+}
+
+async function main() {
+  const { module, agent } = parseArgs();
+  const repoRoot = process.cwd();
+  await createAgentFolder(repoRoot, module, agent);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/bootstrap-module.ts
+++ b/bootstrap-module.ts
@@ -1,0 +1,28 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+async function main() {
+  const [name] = process.argv.slice(2);
+  if (!name) {
+    console.error('Usage: ts-node src/ops/codex-bootloader/bootstrap-module.ts <name>');
+    process.exit(1);
+  }
+
+  const repoRoot = process.cwd();
+  const moduleDir = path.join(repoRoot, 'src', 'modules', name);
+  await fs.mkdir(moduleDir, { recursive: true });
+
+  const bootloaderDir = __dirname;
+  for (const file of ['AGENTS.md', 'TODO.md']) {
+    const src = path.join(bootloaderDir, file);
+    const dest = path.join(moduleDir, file);
+    await fs.copyFile(src, dest);
+  }
+
+  console.log(`Module '${name}' created at ${moduleDir}`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/figma-agent-template/README.md
+++ b/figma-agent-template/README.md
@@ -1,0 +1,8 @@
+# Figma Plugin Template
+
+This folder contains a minimal scaffold for integrating Codex-generated code with the Figma Write API.
+
+- `manifest.json` defines the plugin metadata.
+- `code.js` is executed when the plugin runs.
+
+Codex can export animations as Lottie or MCP-ready data to be injected via this plugin.

--- a/figma-agent-template/code.js
+++ b/figma-agent-template/code.js
@@ -1,0 +1,4 @@
+// Placeholder entry point for Figma plugin.
+// Codex will inject nodes or update components via the Figma Write API.
+
+figma.closePlugin();

--- a/figma-agent-template/manifest.json
+++ b/figma-agent-template/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "Codex Figma Plugin",
+  "id": "com.codex.plugin",
+  "api": "1.0.0",
+  "main": "code.js",
+  "ui": "ui.html"
+}

--- a/run-all.md
+++ b/run-all.md
@@ -1,0 +1,9 @@
+# Run All Modules
+
+This document guides Codex to execute every module's TODO list.
+
+1. Look for `/src/modules/**/TODO.md` in the current repository.
+2. For each module found, read its `AGENTS.md` and `TODO.md` and complete the
+   checklist recursively.
+3. If no modules are present, return control to `src/ops/codex-bootloader/TODO.md`
+   so the bootloader can continue.

--- a/samples/roadmap.md
+++ b/samples/roadmap.md
@@ -1,0 +1,23 @@
+# Sample Roadmap
+
+## Plan
+- **StrategyAgent** drafts the roadmap and agent roles.
+- Output: `roadmap.md`, a task tree with milestones.
+
+## Research
+- **ResearchAgent** gathers market trends and intelligence.
+- Output: `research.md` summarizing key findings.
+
+## Build
+- **DeveloperAgent** writes code based on the design brief.
+- **MCPIntegrationAgent** prepares Figma plugin integration.
+- Output: TypeScript files and `inject_from_schema.js`.
+
+## QA
+- **QAAgent** spawns sub-agents for testing and compliance checks.
+- Output: `test/*.ts`, `runtime-log.json`.
+
+## Deliver
+- **RevealAgent** streams logs for a UI dashboard.
+- **OutcomeAgent** scores engagement and quality.
+- Output: `report.md`, `score.json`.


### PR DESCRIPTION
## Summary
- add `AGENT_TYPES.md` table to list common agent roles
- implement `agent-factory.ts` CLI for creating agents within modules
- provide Figma plugin template for MCP integrations
- include sample roadmap output
- document agent superpowers and quickstart instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6851794a828c8328bb07731929fd5318