### PR TITLE
Add bootstrap docs and run-all stub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,19 @@ It can be invoked in any repository that includes this bootloader.
 
 This agent provides the minimal scaffolding so other agents can begin building
 features immediately.
+
+---
+
+## \ud83d\udce6 Agent Output Guidelines
+
+When Codex scaffolds new agents using this bootloader, it should follow this structure:
+
+For each agent:
+- Create a folder under `/src/modules/<module>/agents/<agent-name>/`
+- Include the following files:
+  - `AGENTS.md` \u2014 defines how this agent operates
+  - `TODO.md` \u2014 task list specific to this agent
+  - `README.md` \u2014 short description of its behavior
+  - `agent-code.ts` \u2014 the logic file for this agent (stub is acceptable)
+
+This ensures all agents are modular, traceable, and bootloader-compatible.

--- a/bootstrap-playbooks/README.md
+++ b/bootstrap-playbooks/README.md
@@ -1,0 +1,15 @@
+# 🧰 Codex Bootloader Playbooks
+
+This folder contains example Codex prompts and modular system scaffolding instructions. These prompts are used to kickstart agent-powered module builds in external or internal repositories.
+
+Each playbook represents a fully structured Codex orchestration plan.
+
+## Format
+
+- `*.md` files represent raw Codex prompts for initializing modules
+- Each file should use only generic, reusable language
+
+## Examples
+
+- `modular-template.md` — generic starter prompt for any Codex module
+- `self-replicating-agents.md` — recursive agent generation flow

--- a/bootstrap-playbooks/modular-template.md
+++ b/bootstrap-playbooks/modular-template.md
@@ -1,0 +1,20 @@
+# 🧠 Codex Prompt: Bootstrap a New Modular Agent System
+
+You are building a new Codex module using the Codex Bootloader system.
+
+Steps:
+
+1. Clone the bootloader to `/src/ops/codex-bootloader/`
+2. Run `bootstrap-module.ts` with the desired module name
+3. Use `agent-factory.ts` to scaffold sub-agents
+4. Begin execution from the generated `TODO.md`
+5. Maintain scope using `.codex-scope.json`
+
+Ensure each agent includes:
+
+- `AGENTS.md`
+- `TODO.md`
+- `README.md`
+- `agent-code.ts`
+
+Do not create global routes, styles, or shared components unless explicitly instructed.

--- a/src/ops/codex-bootloader/run-all.ts
+++ b/src/ops/codex-bootloader/run-all.ts
@@ -1,0 +1,1 @@
+console.log("run-all.ts is not implemented yet. Begin execution from TODO.md manually.");


### PR DESCRIPTION
## Summary
- add run-all.ts stub in `src/ops/codex-bootloader`
- create `bootstrap-playbooks` directory with example prompts
- extend AGENTS.md with agent output guidelines

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6851b3aaf8408328b1483e3d22321381