### PR TITLE
Scaffold Portia adapter

### DIFF
--- a/packages/portia-adapter/README.md
+++ b/packages/portia-adapter/README.md
@@ -1,0 +1,11 @@
+# Bootloader Portia Adapter
+
+This adapter lets Bootloader scaffold Portia plans and tools. Use 
+`boot --portia <project-name>` to generate a Portia-ready project.
+
+## Quickstart
+
+```bash
+boot --portia my-portia-project
+cd my-portia-project
+```

--- a/packages/portia-adapter/package.json
+++ b/packages/portia-adapter/package.json
@@ -1,6 +1,13 @@
 {
   "name": "@gentlyventures/bootloader-portia-adapter",
-  "version": "0.0.0",
-  "private": true
+  "version": "1.0.0",
+  "main": "src/index.js",
+  "scripts": {
+    "build": "echo 'No build needed for Portia adapter'",
+    "test": "echo 'No tests yet'"
+  },
+  "dependencies": {
+    "portia-sdk-python": "^<latest-version>",
+    "@gentlyventures/bootloader-core": "workspace:*"
+  }
 }
-

--- a/packages/portia-adapter/src/index.js
+++ b/packages/portia-adapter/src/index.js
@@ -1,0 +1,8 @@
+const { registerAdapter } = require('@gentlyventures/bootloader-core');
+const portia = require('portia-sdk-python');
+
+function setupPortia(projectName, options) {
+  // TODO: generate Portia plan.py and config using templates
+}
+
+registerAdapter('portia', setupPortia);

--- a/packages/portia-adapter/templates/config.py
+++ b/packages/portia-adapter/templates/config.py
@@ -1,0 +1,1 @@
+# Portia config for {{projectName}}

--- a/packages/portia-adapter/templates/plan.py
+++ b/packages/portia-adapter/templates/plan.py
@@ -1,0 +1,6 @@
+from portia import Plan
+
+class {{projectName}}Plan(Plan):
+    def tasks(self):
+        # Define your Portia tasks here
+        pass

--- a/tools/cli.js
+++ b/tools/cli.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+const core = require('@gentlyventures/bootloader-core');
+
+const args = process.argv.slice(2);
+const options = { portia: false };
+let projectName = '';
+
+for (const arg of args) {
+  if (arg === '--portia') {
+    options.portia = true;
+  } else if (!projectName) {
+    projectName = arg;
+  }
+}
+
+if (options.portia) {
+  core.runAdapter('portia', projectName, options);
+}


### PR DESCRIPTION
## Summary
- scaffold `packages/portia-adapter` with README, package.json, src and templates
- add stub CLI script and Portia adapter registration

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_68542f2f52e88328b554e795b71a8382