### PR TITLE
Add LangGraph adapter stub entry

### DIFF
--- a/packages/langgraph-adapter/package.json
+++ b/packages/langgraph-adapter/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gentlyventures/bootloader-langgraph-adapter",
   "version": "0.0.0",
+  "main": "src/index.js",
   "private": true,
   "scripts": {
     "build": "echo 'No build step yet'",

--- a/packages/langgraph-adapter/src/index.js
+++ b/packages/langgraph-adapter/src/index.js
@@ -1,0 +1,2 @@
+// Stub LangGraph adapter entry point
+module.exports = {};


### PR DESCRIPTION
## Summary
- create `src/index.js` in langgraph-adapter
- wire module entry point in package.json

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a135c6da483288364bfa6013cdba5